### PR TITLE
Fix "internal" ID in parsers

### DIFF
--- a/src/FasTnT.Formatters.Xml/Parsers/XmlEventsParser.cs
+++ b/src/FasTnT.Formatters.Xml/Parsers/XmlEventsParser.cs
@@ -9,11 +9,11 @@ using System.Xml.Linq;
 
 namespace FasTnT.Formatters.Xml.Requests
 {
-    public static class XmlEventsParser
+    public class XmlEventsParser
     { 
-        private static int _customCounter = 0;
+        private int _customCounter = 0;
 
-        internal static EpcisEvent[] ParseEvents(params XElement[] eventList)
+        internal EpcisEvent[] ParseEvents(params XElement[] eventList)
         {
             var events = new List<EpcisEvent>(eventList.Length);
 
@@ -35,7 +35,7 @@ namespace FasTnT.Formatters.Xml.Requests
             return events.ToArray();
         }
 
-        private static EpcisEvent ParseAttributes(XElement root, EpcisEvent epcisEvent)
+        private EpcisEvent ParseAttributes(XElement root, EpcisEvent epcisEvent)
         {
             foreach(var node in root.Elements())
             {
@@ -75,15 +75,15 @@ namespace FasTnT.Formatters.Xml.Requests
                     case "eventID":
                         epcisEvent.EventId = node.Value; break;
                     case "errorDeclaration":
-                        epcisEvent.ErrorDeclaration = node.ToErrorDeclaration(epcisEvent); break;
+                        epcisEvent.ErrorDeclaration = node.ToErrorDeclaration(epcisEvent, this); break;
                     case "transformationId":
                         epcisEvent.TransformationId = node.Value; break;
                     case "bizLocation":
-                        node.ParseBusinessLocation(epcisEvent); break;
+                        node.ParseBusinessLocation(epcisEvent, this); break;
                     case "bizTransactionList":
                         epcisEvent.BusinessTransactions = node.ToBusinessTransactions(); break;
                     case "readPoint":
-                        node.ParseReadPoint(epcisEvent); break;
+                        node.ParseReadPoint(epcisEvent, this); break;
                     case "sourceList":
                         node.ParseSourceInto(epcisEvent.SourceDestinationList); break;
                     case "destinationList":
@@ -104,7 +104,7 @@ namespace FasTnT.Formatters.Xml.Requests
             return epcisEvent;
         }
 
-        private static void ParseExtensionElement(XElement innerElement, EpcisEvent epcisEvent)
+        private void ParseExtensionElement(XElement innerElement, EpcisEvent epcisEvent)
         {
             if (innerElement.Name.Namespace == XNamespace.None || innerElement.Name.Namespace == XNamespace.Xmlns || innerElement.Name.NamespaceName == EpcisNamespaces.Capture)
                 epcisEvent = ParseAttributes(innerElement, epcisEvent);
@@ -112,7 +112,7 @@ namespace FasTnT.Formatters.Xml.Requests
                 epcisEvent.CustomFields.Add(ParseCustomField(innerElement, epcisEvent, FieldType.EventExtension));
         }
 
-        private static void ParseIlmd(XElement element, EpcisEvent epcisEvent)
+        private void ParseIlmd(XElement element, EpcisEvent epcisEvent)
         {
             foreach (var children in element.Elements())
             {
@@ -120,7 +120,7 @@ namespace FasTnT.Formatters.Xml.Requests
             }
         }
 
-        internal static CustomField ParseCustomField(XElement element, EpcisEvent epcisEvent, FieldType type)
+        internal CustomField ParseCustomField(XElement element, EpcisEvent epcisEvent, FieldType type)
         {
             var field = new CustomField
             {

--- a/src/FasTnT.Formatters.Xml/Parsers/XmlMasterDataParser.cs
+++ b/src/FasTnT.Formatters.Xml/Parsers/XmlMasterDataParser.cs
@@ -5,11 +5,11 @@ using FasTnT.Model.MasterDatas;
 
 namespace FasTnT.Formatters.Xml.Requests
 {
-    public static class XmlMasterDataParser
+    public class XmlMasterDataParser
     {
-        private static int _internalId = 0;
+        private int _internalId = 0;
 
-        public static IList<EpcisMasterData> ParseMasterDatas(IEnumerable<XElement> elements)
+        public IList<EpcisMasterData> ParseMasterDatas(IEnumerable<XElement> elements)
         {
             var parsedElements = new List<EpcisMasterData>();
 
@@ -21,12 +21,12 @@ namespace FasTnT.Formatters.Xml.Requests
             return parsedElements;
         }
 
-        private static IEnumerable<EpcisMasterDataHierarchy> ParseHierarchy(IEnumerable<XElement> elements)
+        private IEnumerable<EpcisMasterDataHierarchy> ParseHierarchy(IEnumerable<XElement> elements)
         {
             return elements?.Select(x => new EpcisMasterDataHierarchy { ChildrenId = x.Value }) ?? new EpcisMasterDataHierarchy[0];
         }
 
-        private static IEnumerable<EpcisMasterData> ParseVocabularyElements(string type, IEnumerable<XElement> elements)
+        private IEnumerable<EpcisMasterData> ParseVocabularyElements(string type, IEnumerable<XElement> elements)
         {
             return elements.Select(e =>
             {
@@ -38,7 +38,7 @@ namespace FasTnT.Formatters.Xml.Requests
             });
         }
 
-        private static IEnumerable<MasterDataAttribute> ParseAttributes(IEnumerable<XElement> elements, EpcisMasterData masterData)
+        private IEnumerable<MasterDataAttribute> ParseAttributes(IEnumerable<XElement> elements, EpcisMasterData masterData)
         {
             return elements.Select(element =>
             {
@@ -56,7 +56,7 @@ namespace FasTnT.Formatters.Xml.Requests
             });
         }
 
-        private static IEnumerable<MasterDataField> ParseField(IEnumerable<XElement> elements, MasterDataAttribute attribute, int? parentId = null)
+        private IEnumerable<MasterDataField> ParseField(IEnumerable<XElement> elements, MasterDataAttribute attribute, int? parentId = null)
         {
             var fields = new List<MasterDataField>();
 

--- a/src/FasTnT.Formatters.Xml/Utils/XElementExtensions.cs
+++ b/src/FasTnT.Formatters.Xml/Utils/XElementExtensions.cs
@@ -45,13 +45,13 @@ namespace FasTnT.Formatters.Xml
             return element.Elements("bizTransaction").Select(child => new BusinessTransaction { Type = child.Attribute("type").Value, Id = child.Value }).ToList();
         }
 
-        public static void ParseReadPoint(this XElement element, EpcisEvent Event)
+        public static void ParseReadPoint(this XElement element, EpcisEvent Event, XmlEventsParser parser)
         {
             Event.ReadPoint = element.Element("id").Value;
 
             foreach (var innerElement in element.Elements().Where(x => x.Name.Namespace != XNamespace.None))
             {
-                Event.CustomFields.Add(XmlEventsParser.ParseCustomField(innerElement, Event, FieldType.ReadPointExtension));
+                Event.CustomFields.Add(parser.ParseCustomField(innerElement, Event, FieldType.ReadPointExtension));
             }
         }
 
@@ -81,21 +81,21 @@ namespace FasTnT.Formatters.Xml
             }
         }
 
-        public static void ParseBusinessLocation(this XElement element, EpcisEvent Event)
+        public static void ParseBusinessLocation(this XElement element, EpcisEvent Event, XmlEventsParser parser)
         {
             foreach (var innerElement in element.Elements().Where(x => !new[] { "id", "corrective" }.Contains(x.Name.LocalName)))
             {
-                Event.CustomFields.Add(XmlEventsParser.ParseCustomField(innerElement, Event, FieldType.BusinessLocationExtension));
+                Event.CustomFields.Add(parser.ParseCustomField(innerElement, Event, FieldType.BusinessLocationExtension));
             }
 
             Event.BusinessLocation = element.Element("id").Value;
         }
 
-        public static ErrorDeclaration ToErrorDeclaration(this XElement element, EpcisEvent Event)
+        public static ErrorDeclaration ToErrorDeclaration(this XElement element, EpcisEvent Event, XmlEventsParser parser)
         {
             foreach (var innerElement in element.Elements().Where(x => !new[] { "id", "corrective" }.Contains(x.Name.LocalName)))
             {
-                Event.CustomFields.Add(XmlEventsParser.ParseCustomField(innerElement, Event, FieldType.ErrorDeclarationExtension));
+                Event.CustomFields.Add(parser.ParseCustomField(innerElement, Event, FieldType.ErrorDeclarationExtension));
             }
 
             var declarationTime = DateTime.Parse(element.Element("declarationTime").Value, CultureInfo.InvariantCulture);

--- a/src/FasTnT.Formatters.Xml/XmlRequestFormatter.cs
+++ b/src/FasTnT.Formatters.Xml/XmlRequestFormatter.cs
@@ -16,6 +16,8 @@ namespace FasTnT.Formatters.Xml
     {
         public Request Read(Stream input)
         {
+            var eventParser = new XmlEventsParser();
+            var masterdataParser = new XmlMasterDataParser();
             var document = XmlDocumentParser.Instance.Load(input);
 
             if (document.Root.Name == XName.Get("EPCISDocument", EpcisNamespaces.Capture))
@@ -24,7 +26,7 @@ namespace FasTnT.Formatters.Xml
                 {
                     CreationDate = DateTime.Parse(document.Root.Attribute("creationDate").Value, CultureInfo.InvariantCulture),
                     SchemaVersion = document.Root.Attribute("schemaVersion").Value,
-                    EventList = XmlEventsParser.ParseEvents(document.Root.XPathSelectElement("EPCISBody/EventList").Elements().ToArray())
+                    EventList = eventParser.ParseEvents(document.Root.XPathSelectElement("EPCISBody/EventList").Elements().ToArray())
                 };
             }
             else if (document.Root.Name == XName.Get("EPCISQueryDocument", EpcisNamespaces.Query)) // Subscription result
@@ -33,7 +35,7 @@ namespace FasTnT.Formatters.Xml
                 {
                     CreationDate = DateTime.Parse(document.Root.Attribute("creationDate").Value, CultureInfo.InvariantCulture),
                     SchemaVersion = document.Root.Attribute("schemaVersion").Value,
-                    EventList = XmlEventsParser.ParseEvents(document.Root.Element("EPCISBody").Element(XName.Get("QueryResults", EpcisNamespaces.Query)).Element("resultsBody").Element("EventList").Elements().ToArray())
+                    EventList = eventParser.ParseEvents(document.Root.Element("EPCISBody").Element(XName.Get("QueryResults", EpcisNamespaces.Query)).Element("resultsBody").Element("EventList").Elements().ToArray())
                 };
             }
             else if (document.Root.Name == XName.Get("EPCISMasterDataDocument", EpcisNamespaces.MasterData))
@@ -42,7 +44,7 @@ namespace FasTnT.Formatters.Xml
                 {
                     CreationDate = DateTime.Parse(document.Root.Attribute("creationDate").Value, CultureInfo.InvariantCulture),
                     SchemaVersion = document.Root.Attribute("schemaVersion").Value,
-                    MasterDataList = XmlMasterDataParser.ParseMasterDatas(document.Root.Element("EPCISBody").Element("VocabularyList").Elements("Vocabulary"))
+                    MasterDataList = masterdataParser.ParseMasterDatas(document.Root.Element("EPCISBody").Element("VocabularyList").Elements("Vocabulary"))
                 };
             }
 


### PR DESCRIPTION
Set customCounter field local (per parser instance) to avoid concurrency issues. 