### PR TITLE
#47 Hide PgSQL related messages in exception messages

### DIFF
--- a/src/FasTnT.Host/Middleware/ExceptionHandling/ExceptionHandlingMiddleware.cs
+++ b/src/FasTnT.Host/Middleware/ExceptionHandling/ExceptionHandlingMiddleware.cs
@@ -13,11 +13,13 @@ namespace FasTnT.Host.Middleware
         const int BadRequest = 400, InternalServerError = 500;
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
+        private readonly bool _developmentMode;
 
-        public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+        public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger, bool developmentMode)
         {
             _next = next;
             _logger = logger;
+            _developmentMode = developmentMode;
         } 
 
         public async Task Invoke(HttpContext context)
@@ -39,11 +41,13 @@ namespace FasTnT.Host.Middleware
                 {
                     Exception = (epcisException?.ExceptionType ?? ExceptionType.ImplementationException).DisplayName,
                     Severity = epcisException?.Severity ?? ExceptionSeverity.Error,
-                    Reason = ex.Message
+                    Reason = GetMessage(ex)
                 };
 
                 await context.SetEpcisResponse(response, (ex is EpcisException) ? BadRequest : InternalServerError, context.RequestAborted);
             }
         }
+
+        private string GetMessage(Exception ex) => ex is EpcisException || _developmentMode ? ex.Message : "An unexpected error occured.";
     }
 }

--- a/src/FasTnT.Host/Middleware/MiddlewareExtensions.cs
+++ b/src/FasTnT.Host/Middleware/MiddlewareExtensions.cs
@@ -5,7 +5,7 @@ namespace FasTnT.Host.Middleware
 {
     public static class MiddlewareExtensions
     {
-        public static IApplicationBuilder UseExceptionHandlingMiddleware(this IApplicationBuilder builder) => builder.UseMiddleware<ExceptionHandlingMiddleware>();
+        public static IApplicationBuilder UseExceptionHandlingMiddleware(this IApplicationBuilder builder, bool isDevelopment = false) => builder.UseMiddleware<ExceptionHandlingMiddleware>(isDevelopment);
         public static IApplicationBuilder UseEpcisCaptureEndpoint(this IApplicationBuilder app, string path) => app.UseMiddleware<EpcisCaptureMiddleware>(path);
         public static IApplicationBuilder UseEpcisQueryEndpoint(this IApplicationBuilder app, string path) => app.UseMiddleware<EpcisQueryMiddleware>(path);
         public static IApplicationBuilder UseEpcisSubscriptionTrigger(this IApplicationBuilder app, string path) => app.UseMiddleware<EpcisSubscriptionTriggerMiddleware>(path);

--- a/src/FasTnT.Host/Startup.cs
+++ b/src/FasTnT.Host/Startup.cs
@@ -48,14 +48,14 @@ namespace FasTnT.Host
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             SubscriptionBackgroundService.DelayTimeoutInMs = Configuration.GetSection("Settings").GetValue("SubscriptionWaitTimeout", 5000);
+            var isDevelopment = env.IsDevelopment();
 
-            if (env.IsDevelopment())
+            if (isDevelopment)
             {
-                app.UseDeveloperExceptionPage()
-                   .UseEpcisMigrationEndpoint($"{EpcisServicePath}/Database");
+                app.UseEpcisMigrationEndpoint($"{EpcisServicePath}/Database");
             }
 
-            app.UseExceptionHandlingMiddleware()
+            app.UseExceptionHandlingMiddleware(isDevelopment)
                .UseWhen(context => context.Request.Path.StartsWithSegments(EpcisServicePath), x => {
                     x.UseBasicAuthentication("FasTnT")
                      .UseEpcisCaptureEndpoint($"{EpcisServicePath}/Capture")


### PR DESCRIPTION
Only show PgSQL messages in development mode, to ease the debugging process