### PR TITLE
Fix formatter dependencies

### DIFF
--- a/src/FasTnT.Domain/FasTnT.Domain.csproj
+++ b/src/FasTnT.Domain/FasTnT.Domain.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FasTnT.Formatters.Xml\FasTnT.Formatters.Xml.csproj" />
     <ProjectReference Include="..\FasTnT.Formatters\FasTnT.Formatters.csproj" />
     <ProjectReference Include="..\FasTnT.Model\FasTnT.Model.csproj" />
   </ItemGroup>

--- a/src/FasTnT.Domain/Services/Subscriptions/ResultSending/HttpSubscriptionResultSender.cs
+++ b/src/FasTnT.Domain/Services/Subscriptions/ResultSending/HttpSubscriptionResultSender.cs
@@ -1,4 +1,4 @@
-﻿using FasTnT.Formatters.Xml;
+﻿using FasTnT.Formatters;
 using FasTnT.Model.Responses;
 using System;
 using System.Net;
@@ -13,7 +13,7 @@ namespace FasTnT.Domain.Services.Subscriptions
     {
         public async Task Send(string destination, IEpcisResponse epcisResponse, CancellationToken cancellationToken)
         {
-            var formatter = XmlFormatter.Instance;
+            var formatter = EpcisFormatter.Default;
             var request = WebRequest.CreateHttp(destination);
             request.Method = "POST";
             request.ContentType = formatter.ContentType;

--- a/src/FasTnT.Formatters/EpcisFormatter.cs
+++ b/src/FasTnT.Formatters/EpcisFormatter.cs
@@ -1,0 +1,7 @@
+﻿namespace FasTnT.Formatters
+{
+    public static class EpcisFormatter
+    {
+        public static IFormatter Default { get; set; }
+    }
+}

--- a/src/FasTnT.Host/Startup.cs
+++ b/src/FasTnT.Host/Startup.cs
@@ -12,6 +12,8 @@ using FasTnT.Host.Infrastructure.Binding;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authentication;
 using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+using FasTnT.Formatters;
+using FasTnT.Formatters.Xml;
 
 namespace FasTnT.Host
 {
@@ -56,6 +58,7 @@ namespace FasTnT.Host
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            EpcisFormatter.Default = XmlFormatter.Instance;
             Constants.SubscriptionTaskDelayTimeoutInMs = Configuration.GetSection("Settings").GetValue("SubscriptionWaitTimeout", 5000);
 
             app.UseExceptionHandlingMiddleware(env.IsDevelopment())


### PR DESCRIPTION
Domain project should not be aware of any implementation of Formatters.
Make the host set the default formatter, and remove XML implementation reference from domain project.